### PR TITLE
cleanup: Remove unnecessary Result types in functions that doesn't have any function that return a Result type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "glassy"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,14 @@
 [package]
 name = "glassy"
-authors = ["decipher"]
-version = "0.1.0"
+authors = ["decipher", "Rhelvetican"]
+version = "0.1.1"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-image = "0.25.1"
-imageproc = "0.24.0"
-thiserror = "1.0.58"
-clap = { version = "4.5.4" , features = ["derive"]}
-libblur = "0.9.4"
-log = "0.4.21"
-env_logger = "0.11.3"
+image = "0.25"
+imageproc = "0.24"
+thiserror = "1.0"
+clap = { version = "4.5", features = ["derive"] }
+libblur = "0.9"
+log = "0.4"
+env_logger = "0.11"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,11 +1,13 @@
+use image::ImageError as ImgError;
+use std::{io::Error as IoError, result::Result as StdResult};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("No such file or directory")]
-    FileNotFound(#[from] std::io::Error),
+    FileNotFound(#[from] IoError),
     #[error("Invalid image file")]
-    DecodeError(#[from] image::ImageError),
+    DecodeError(#[from] ImgError),
 }
 
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = StdResult<T, Error>;

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,34 +1,36 @@
 use crate::utils::cli::CliArgs;
+use env_logger::Builder;
+use log::{Level, LevelFilter};
 use std::io::Write;
 
 pub fn init_logger(cli_args: &CliArgs) {
     let mut level = log::LevelFilter::Error;
 
     if cli_args.verbose {
-        level = log::LevelFilter::Info;
+        level = LevelFilter::Info;
     }
 
-    env_logger::Builder::new()
-    .format(|buf, record| {
-        let info_style = buf.default_level_style(log::Level::Info);
-        let error_style = buf.default_level_style(log::Level::Error);
+    Builder::new()
+        .format(|buf, record| {
+            let info_style = buf.default_level_style(Level::Info);
+            let error_style = buf.default_level_style(Level::Error);
 
-        match record.level() {
-            log::Level::Error => writeln!(
-                buf,
-                "{error_style}{}{error_style:#}: {}",
-                record.level(),
-                record.args()
-            ),
-            log::Level::Info => writeln!(
-                buf,
-                "{info_style}{}{info_style:#}: {}",
-                record.level(),
-                record.args()
-            ),
-            _ => writeln!(buf, "{}: {}", record.level(), record.args()),
-        }
-    })
-    .filter(None, level)
-    .init();
+            match record.level() {
+                Level::Error => writeln!(
+                    buf,
+                    "{error_style}{}{error_style:#}: {}",
+                    record.level(),
+                    record.args()
+                ),
+                Level::Info => writeln!(
+                    buf,
+                    "{info_style}{}{info_style:#}: {}",
+                    record.level(),
+                    record.args()
+                ),
+                _ => writeln!(buf, "{}: {}", record.level(), record.args()),
+            }
+        })
+        .filter(None, level)
+        .init();
 }

--- a/src/utils/blur.rs
+++ b/src/utils/blur.rs
@@ -1,11 +1,11 @@
-use image::{RgbImage, DynamicImage, ImageError};
+use image::{DynamicImage, RgbImage};
 use libblur::{fast_gaussian, FastBlurChannels};
 
 pub struct BlurOpts {
     pub sigma: f32,
 }
 
-pub fn add_blur(img: DynamicImage, blur_opts: BlurOpts) -> Result<DynamicImage, ImageError> {
+pub fn add_blur(img: DynamicImage, blur_opts: BlurOpts) -> DynamicImage {
     let height: u32 = img.height();
 
     let width: u32 = img.width();
@@ -23,5 +23,5 @@ pub fn add_blur(img: DynamicImage, blur_opts: BlurOpts) -> Result<DynamicImage, 
 
     let final_img = RgbImage::from_raw(width, height, raw_img).unwrap();
 
-    Ok(DynamicImage::from(final_img))
+    DynamicImage::from(final_img)
 }

--- a/src/utils/cli.rs
+++ b/src/utils/cli.rs
@@ -1,5 +1,5 @@
 use crate::utils::effect::EffectStrength;
-use clap::Parser;
+use clap::{Parser, ValueHint};
 
 /// A simple CLI tool to apply glass-like overlay effect to images
 #[derive(Debug, Parser)]
@@ -8,7 +8,7 @@ pub struct CliArgs {
     /// Path to image file
     #[arg(
         value_name = "PATH",
-        value_hint = clap::ValueHint::FilePath
+        value_hint = ValueHint::FilePath
     )]
     pub path: String,
 
@@ -22,9 +22,7 @@ pub struct CliArgs {
     pub effect_strength: EffectStrength,
 
     /// Apply effect without grain
-    #[arg(
-        long="no-grain"
-    )]
+    #[arg(long = "no-grain")]
     pub no_grain: bool,
 
     /// Explain what is being done

--- a/src/utils/effect.rs
+++ b/src/utils/effect.rs
@@ -1,7 +1,7 @@
 use crate::utils::{blur::BlurOpts, noise::NoiseOpts};
-use std::{cmp::min, fmt};
 use clap::ValueEnum;
 use image::DynamicImage;
+use std::{cmp::min, fmt};
 
 #[derive(ValueEnum, Debug, Copy, Clone)]
 pub enum EffectStrength {

--- a/src/utils/noise.rs
+++ b/src/utils/noise.rs
@@ -1,4 +1,4 @@
-use image::{DynamicImage, ImageError};
+use image::DynamicImage;
 use imageproc::noise::gaussian_noise;
 
 pub struct NoiseOpts {
@@ -7,11 +7,11 @@ pub struct NoiseOpts {
     pub seed: u64,
 }
 
-pub fn add_noise(img: DynamicImage, noise_opts: NoiseOpts) -> Result<DynamicImage, ImageError> {
-    Ok(DynamicImage::from(gaussian_noise(
+pub fn add_noise(img: DynamicImage, noise_opts: NoiseOpts) -> DynamicImage {
+    DynamicImage::from(gaussian_noise(
         &DynamicImage::into_rgb8(img),
         noise_opts.mean,
         noise_opts.std_dev,
-        noise_opts.seed
-    )))
+        noise_opts.seed,
+    ))
 }


### PR DESCRIPTION
Theortically there's the function `RgbImage::from_raw()` in `src/utils/blur.rs` that can possibly fail if it unwrap a `None` variant of the `Option` which should not fail though.